### PR TITLE
Add DOCKERFILE_SYNTAX env variable

### DIFF
--- a/docker-squash.sh
+++ b/docker-squash.sh
@@ -13,6 +13,12 @@ if [ ! -x "$(command -v docker)" ]; then
     exit 1
 fi
 
+# Check if jq is installed, if not exit
+if [ ! -x "$(command -v jq)" ]; then
+    echo "jq is not installed. Please install jq and try again." >&2
+    exit 1
+fi
+
 # HELPER FUNCTIONS
 ################################################################################
 

--- a/docker-squash.sh
+++ b/docker-squash.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ################################################################################
 # The setups in this file belong to https://code.shin.company/docker-squash
 # I appreciate you respecting my intellectual efforts in creating them.

--- a/docker-squash.sh
+++ b/docker-squash.sh
@@ -29,6 +29,12 @@ Usage: ${0##*/} <source_image> [build_options]
                    An absolute path to your Dockerfile can also be used.
     build_options  Optional Docker build options like --build-arg, --label, etc.
 
+  Env Variables:
+    DOCKERFILE_SYNTAX
+                   Defaults to docker/dockerfile:1
+                   Normally there is no reason to change this unless you don't have access to docker.io from your network.
+                   Or want to use a local cache.
+
 Author:  SHIN Company <shin@shin.company>
 License: https://code.shin.company/docker-squash/blob/main/LICENSE
 
@@ -75,6 +81,8 @@ get_healthcheck() { parse_config "$1" '.Healthcheck // empty|(
     (.Test[0]|sub("-SHELL";"")) + " " + .Test[1]
 )'; }
 
+DOCKERFILE_SYNTAX="${DOCKERFILE_SYNTAX:-docker/dockerfile:1}"
+
 generate() {
     local id="$(get_id "$1")"
 
@@ -98,9 +106,10 @@ generate() {
     local cmd="$(get_cmd "$id")"
     local stopsignal="$(get_stopsignal "$id")"
     local healthcheck="$(get_healthcheck "$id")"
+    local syntax="${DOCKERFILE_SYNTAX}"
 
     awk NF <<Dockerfile
-# syntax=docker/dockerfile:1
+# syntax=$syntax
 
 ################################################################################
 # Base image: $tag (Image ID: $id)


### PR DESCRIPTION
- This is necessary when you don't have access to docker.io for some reason (firewalls/proxy/etc.). Or when you want to use a local cache (e.g. artifactory).