### PR TITLE
Use bash instead of sh as syntax is not POSIX compliant.

### DIFF
--- a/docker-squash.sh
+++ b/docker-squash.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ################################################################################
 # The setups in this file belong to https://code.shin.company/docker-squash
 # I appreciate you respecting my intellectual efforts in creating them.


### PR DESCRIPTION
From shellcheck
- In POSIX sh, 'local' is undefined.
- In POSIX sh, &> is undefined.